### PR TITLE
adding automatic CUDA architecture detection, clang-format stuff

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+
+# version: 3.9
+# include: *.h
+# include: *.c
+# include: *.hpp
+# include: *.tpp
+# include: *.ipp
+# include: *.cpp
+# include: *.cxx
+# exclude: tpl/*
+# exlcude: third_party/*
+
+# Defines the Chromium style for automatic reformatting.
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle: Google
+
+# This defaults to 'Auto'. Explicitly set it for a while, so that
+# 'vector<vector<int> >' in existing files gets formatted to
+# 'vector<vector<int>>'. ('Auto' means that clang-format will only use
+# 'int>>' if the file already contains at least one such instance.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,17 @@ message(STATUS "USE_OPEN  : " ${USE_OPEN})
 message(STATUS "USE_MKL   : " ${USE_MKL})
 message(STATUS "USE_OPENMP : " ${USE_OPENMP})
 
+set(CMAKE_MODULE_PATH
+    ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
+
+if(NOT CUDA_ARCH)
+    message(STATUS "cuda arch wasn't provided, running feature test")
+    include(feature_test)
+else()
+    set(CUDA_GEN_CODE "-gencode arch=compute_${CUDA_ARCH},code=sm_${CUDA_ARCH}")
+endif()
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}; ${CUDA_GEN_CODE}")
+
 if(WIN32 AND MSVC)
     set(BUILD_FLAGS
 	"${CMAKE_C_FLAGS} /O3 /MP")

--- a/cmake/feature_test/cuda_gencode_test.cpp
+++ b/cmake/feature_test/cuda_gencode_test.cpp
@@ -1,0 +1,17 @@
+#include <cuda_runtime.h>
+#include <stdio.h>
+
+int main() {
+  cudaDeviceProp prop;
+  cudaError_t status = cudaGetDeviceProperties(&prop, 0);
+
+  if (status != cudaSuccess) {
+    printf("%s", cudaGetErrorString(status));
+    return 1;
+  }
+
+  int v = prop.major * 10 + prop.minor;
+  printf("-gencode arch=compute_%d,code=sm_%d\n", v, v);
+
+  return 0;
+}

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,1 @@
+find ./ -iname *.c -o -iname *.h -o -iname *.tpp -o -iname *.cpp | xargs clang-format -i


### PR DESCRIPTION
setting CUDA_ARCH will automatically set nvcc platform flags.
if CUDA_ARCH is not set, cmake will automatically detect it

running `sh format.sh` on the root directory will recursively run clang-format
the .clang-format file sets the formatting style